### PR TITLE
Fix the python wrapper of the moment version

### DIFF
--- a/MOMENT_DISP_F90_OPENMP/src/axitra.py
+++ b/MOMENT_DISP_F90_OPENMP/src/axitra.py
@@ -470,11 +470,11 @@ class force:
         '''
 
         try:
-            import convfPy
+            import convmPy
         except:
             import sys
             sys.path.append(ap.axpath)
-            import convfPy
+            import convmPy
         import os
 
         #check if axi_??.data files exists
@@ -515,7 +515,7 @@ class force:
 
 
         # run convolution
-        convfPy.force_conv(ap.id, source_type, t0, t1, unit, sismox, sismoy, sismoz)
+        convmPy.moment_conv(ap.id, source_type, t0, t1, unit, sismox, sismoy, sismoz)
 
         # create time vector
         dt = ap.duration/ap.npt


### PR DESCRIPTION
I looks that the axitra.py in the moment version has been at least initially copy-pasted from the force version. It imports convfPy instead of convmPy and calls convfPy.force_conv instead of convmPy.moment_conv.