### PR TITLE
fix max random id

### DIFF
--- a/FORCE_DISP_F90_OPENMP/src/axitra.py
+++ b/FORCE_DISP_F90_OPENMP/src/axitra.py
@@ -122,7 +122,7 @@ class Axitra:
             self.id = id
             self.sid = 'axi_' + str(self.id)
         else:
-            self.id = random.randint(1,1000)
+            self.id = random.randint(1,999)
             self.sid = 'axi_'+str(self.id)
 
     def clean(self):

--- a/MOMENT_DISP_F90_OPENMP/src/axitra.py
+++ b/MOMENT_DISP_F90_OPENMP/src/axitra.py
@@ -122,7 +122,7 @@ class Axitra:
             self.id = id
             self.sid = 'axi_' + str(self.id)
         else:
-            self.id = random.randint(1,1000)
+            self.id = random.randint(1,999)
             self.sid = 'axi_'+str(self.id)
 
     def clean(self):


### PR DESCRIPTION
randint returns: `A random integer in range [start, end] including the end points.`
https://www.geeksforgeeks.org/python-randint-function/
(else if id=1000, I get the error:

```
running openMp on            4  threads
freq   200/  200 iter=      605 Done
/export/dump/ulrich/axitra/MOMENT_DISP_F90_OPENMP/src/axitra ran sucessfully
At line 102 of file convmPy.f90 (unit = 10, file = 'axi_***.data')
Fortran runtime error: End of file
```
)